### PR TITLE
fix deprecation warning "Using tests as filters is deprecated"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,7 @@
     state: stopped
     enabled: no
   register: disable_service_result
-  failed_when: disable_service_result | failed and ('Could not find the requested service' not in disable_service_result.msg)
+  failed_when: (disable_service_result is failed) and ('Could not find the requested service' not in disable_service_result.msg)
   with_items:
     - ntpd
     - systemd-timesyncd


### PR DESCRIPTION
the full deprecation warning is:

```
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|failed` use `result is failed`. This feature will be removed in version 2.9. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```