### PR TITLE
Added the option to create peers with other chrony servers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ For more information about `chrony`, please check [the official project page](ht
 | `chrony_timezone`           | Path to the configuration file.                                                | `Etc/UTC`                              |
 | `chrony_ntp_pools`          | A list of NTP pools to use, with their options.                                | `[ 'pool.ntp.org iburst maxpoll 10' ]` |
 | `chrony_ntp_servers`        | A list of NTP servers to use, with their options.                              | `[]`                                   |
+| `chrony_ntp_peers`          | A list of NTP peers to use, with their options.                                | `[]`                                   |
 | `chrony_config_file`        | Path to chrony configuration file.                                             | `/etc/chrony.conf`                     |
 | `chrony_config_logdir`      | Path to chrony logs directory.                                                 | `/var/log/chrony`                      |
 | `chrony_config_driftfile`   | Path to chrony drift file.                                                     | `/var/lib/chrony/drift`                |
@@ -44,6 +45,10 @@ chrony_ntp_servers:
   - 1.rhel.pool.ntp.org iburst maxpoll 10
   - 2.rhel.pool.ntp.org iburst maxpoll 10
   - 3.rhel.pool.ntp.org iburst maxpoll 10
+chrony_ntp_peers:
+  - ntp00.example.com iburst maxpoll 10
+  - ntp01.example.com iburst maxpoll 10
+  - ntp02.example.com iburst maxpoll 10
 chrony_config_file: /etc/chrony.conf
 chrony_config_driftfile: /var/lib/chrony/drift
 chrony_makestep_threshold: 5

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ chrony_ntp_servers:
   - 2.rhel.pool.ntp.org iburst maxpoll 10
   - 3.rhel.pool.ntp.org iburst maxpoll 10
 chrony_ntp_peers:
-  - ntp00.example.com iburst maxpoll 10
-  - ntp01.example.com iburst maxpoll 10
-  - ntp02.example.com iburst maxpoll 10
+  - ntp00.example.com maxpoll 10
+  - ntp01.example.com maxpoll 10
+  - ntp02.example.com maxpoll 10
 chrony_config_file: /etc/chrony.conf
 chrony_config_driftfile: /var/lib/chrony/drift
 chrony_makestep_threshold: 5

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ chrony_timezone: "Etc/UTC"
 chrony_ntp_pools:
   - pool.ntp.org iburst maxpoll 10
 chrony_ntp_servers: []
+chrony_ntp_peers: []
 chrony_config_file: /etc/chrony.conf
 chrony_config_logdir: /var/log/chrony
 chrony_config_driftfile: /var/lib/chrony/drift

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -17,7 +17,7 @@ pool {{ pool }}
 {% endif %}
 
 {% if chrony_ntp_peers|length > 0 %}
-# List of NTP Peers to use
+# List of NTP peers to use
 {% for peer in chrony_ntp_peers %}
 peer {{ peer }}
 {% endfor %}

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -16,6 +16,13 @@ pool {{ pool }}
 {% endfor %}
 {% endif %}
 
+{% if chrony_ntp_peers|length > 0 %}
+# List of NTP Peers to use
+{% for peer in chrony_ntp_peers %}
+peer {{ peer }}
+{% endfor %}
+{% endif %}
+
 # Drift file
 driftfile {{ chrony_config_driftfile }}
 


### PR DESCRIPTION
I added the option to have chrony servers peer with other servers.  The change is minimal and essentially a copy and paste of the `chrony_ntp_servers` section in the template.