### PR TITLE
Added Ubuntu 22.04 task as symlink to Debian-10 task

### DIFF
--- a/tasks/Ubuntu-22.04.yml
+++ b/tasks/Ubuntu-22.04.yml
@@ -1,0 +1,1 @@
+./Debian-10.yml


### PR DESCRIPTION
Hey @Frzk, first of all thanks for the role!

I've added Ubuntu 22.04 to the list of tasks as symlink to Debian 10, because it was breaking the whole logic of the role.

Fix is pretty straight-forward:
* task is using `Frzk.chrony/tasks/Ubuntu-22.04.yml` instead of default one `Frzk.chrony/tasks/Linux.yml`.

Please review :pray: 